### PR TITLE
Added default daemon_settings fix for Centos7 issue with abstract socket when daemon installed as external mode

### DIFF
--- a/manifests/agent/php.pp
+++ b/manifests/agent/php.pp
@@ -42,6 +42,12 @@
 #   Sockets in RedHat 7. Can be overridden using the ini_settings parameter.
 #   Default: OS dependant - see params.pp (Hash)
 #
+# [*default_daemon_settings*]
+#   Default settings to pass to newrelic.cfg - these are used to make
+#   OS-specific changes to the newrelic.cfg file, for example using Abstract
+#   Sockets in RedHat 7. Can be overridden using the daemon_settings parameter.
+#   Default: OS dependant - see params.pp (Hash)
+#
 # [*exec_path*]
 #   $PATH environment variable to pass to exec resources within this class,
 #   most noteably the NewRelic installer script. You may wish to override this

--- a/manifests/agent/php.pp
+++ b/manifests/agent/php.pp
@@ -97,18 +97,19 @@
 #
 class newrelic::agent::php (
   String                   $license_key,
-  Boolean                  $manage_repo          = $::newrelic::params::manage_repo,
-  String                   $conf_dir             = $::newrelic::params::php_conf_dir,
-  Array                    $purge_files          = $::newrelic::params::php_purge_files,
-  String                   $package_name         = $::newrelic::params::php_package_name,
-  String                   $daemon_service_name  = $::newrelic::params::php_service_name,
-  Array                    $extra_packages       = $::newrelic::params::php_extra_packages,
-  Hash                     $default_ini_settings = $::newrelic::params::php_default_ini_settings,
-  String                   $exec_path            = $facts['path'],
-  String                   $package_ensure       = 'present',
-  Enum['agent','external'] $startup_mode         = 'agent',
-  Hash                     $ini_settings         = {},
-  Hash                     $daemon_settings      = {},
+  Boolean                  $manage_repo             = $::newrelic::params::manage_repo,
+  String                   $conf_dir                = $::newrelic::params::php_conf_dir,
+  Array                    $purge_files             = $::newrelic::params::php_purge_files,
+  String                   $package_name            = $::newrelic::params::php_package_name,
+  String                   $daemon_service_name     = $::newrelic::params::php_service_name,
+  Array                    $extra_packages          = $::newrelic::params::php_extra_packages,
+  Hash                     $default_ini_settings    = $::newrelic::params::php_default_ini_settings,
+  Hash                     $default_daemon_settings = $::newrelic::params::php_default_daemon_settings,
+  String                   $exec_path               = $facts['path'],
+  String                   $package_ensure          = 'present',
+  Enum['agent','external'] $startup_mode            = 'agent',
+  Hash                     $ini_settings            = {},
+  Hash                     $daemon_settings         = {},
 ) inherits newrelic::params {
 
   if $startup_mode == 'agent' {
@@ -173,6 +174,8 @@ class newrelic::agent::php (
     content => template('newrelic/php/newrelic.ini.erb'),
     require => Exec['newrelic_kill'],
   }
+
+  $all_daemon_settings = deep_merge($default_daemon_settings,$daemon_settings)
 
   file { '/etc/newrelic/newrelic.cfg':
     ensure  => $daemon_config_ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,19 +35,24 @@ class newrelic::params {
         $php_default_ini_settings = {
           'daemon.port' => '"@newrelic-daemon"'
         }
+        $php_default_daemon_settings = {
+          'port' => '"@newrelic-daemon"'
+        }
       } else {
         $php_default_ini_settings = {}
+        $php_default_daemon_settings = {}
       }
     }
 
     'Debian': {
-      $manage_repo              = true
-      $server_package_name      = 'newrelic-sysmond'
-      $server_service_name      = 'newrelic-sysmond'
-      $php_package_name         = 'newrelic-php5'
-      $php_service_name         = 'newrelic-daemon'
-      $php_default_ini_settings = {}
-      $php_extra_packages       = []
+      $manage_repo                 = true
+      $server_package_name         = 'newrelic-sysmond'
+      $server_service_name         = 'newrelic-sysmond'
+      $php_package_name            = 'newrelic-php5'
+      $php_service_name            = 'newrelic-daemon'
+      $php_default_ini_settings    = {}
+      $php_default_daemon_settings = {}
+      $php_extra_packages          = []
 
       if $facts['os']['release']['full'] == '16.04' {
         $php_conf_dir        = '/etc/php/7.0/mods-available'

--- a/templates/daemon/newrelic.cfg.erb
+++ b/templates/daemon/newrelic.cfg.erb
@@ -3,6 +3,6 @@
 # Managed by Puppet - DO NOT modify locally!
 ############################################
 
-<% scope['::newrelic::agent::php::daemon_settings'].each do |k,v| -%>
+<% scope['::newrelic::agent::php::all_daemon_settings'].each do |k,v| -%>
 <%= k %>=<%= v %>
 <%- end -%>


### PR DESCRIPTION
When NewRelic daemon is installed as external mode, the port fix for Redhat 7 system is not presented in /etc/newrelic/newrelic.cfg file. This PR is to address this issue.

Pretty much follow the same pattern as default_ini_settings, I have added default_daemon_settings.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
