### PR TITLE
Prevent apt errors after initial run and puppet failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Release notes for the claranet/puppet-newrelic module.
 
 ------------------------------------------
 
+## 2.1.1 - 2018-02-01
+  * Fork to fix olx Indonesia problem with apt-get update missing
+
 ## 2.1.0 - 2017-11-22
   * PHP Agent: Fixed a bug where the `newrelic-daemon` service would flap if the start-up mode was set to `agent` - [#13](https://github.com/claranet/puppet-newrelic/issues/13)
   * PHP Agent: New parameter: `default_daemon_settings` for external start-up mode - [#12](https://github.com/claranet/puppet-newrelic/pull/12)

--- a/manifests/repo/infra.pp
+++ b/manifests/repo/infra.pp
@@ -39,6 +39,11 @@ class newrelic::repo::infra {
           src => false,
         },
         require  => Package['apt-transport-https'],
+      } ~> exec { 'newrelic-apt-update':
+        command     => 'apt-get update',
+        cwd         => '/tmp',
+        refreshonly => true,
+        path        => ['/usr/bin'],
       }
     }
 

--- a/manifests/repo/legacy.pp
+++ b/manifests/repo/legacy.pp
@@ -12,6 +12,13 @@
 #
 class newrelic::repo::legacy {
 
+  exec { 'newrelic-legacy-apt-update':
+    command     => 'apt-get update',
+    cwd         => '/tmp',
+    refreshonly => true,
+    path        => ['/usr/bin'],
+  }
+
   case $facts['os']['family'] {
     'RedHat' : {
       $require = Package['newrelic-repo-5-3.noarch']
@@ -35,6 +42,11 @@ class newrelic::repo::legacy {
           src => false,
         },
         release  => 'newrelic',
+      } ~> exec { 'newrelic-legacy-apt-update':
+        command     => 'apt-get update',
+        cwd         => '/tmp',
+        refreshonly => true,
+        path        => ['/usr/bin'],
       }
     }
 

--- a/manifests/repo/legacy.pp
+++ b/manifests/repo/legacy.pp
@@ -12,13 +12,6 @@
 #
 class newrelic::repo::legacy {
 
-  exec { 'newrelic-legacy-apt-update':
-    command     => 'apt-get update',
-    cwd         => '/tmp',
-    refreshonly => true,
-    path        => ['/usr/bin'],
-  }
-
   case $facts['os']['family'] {
     'RedHat' : {
       $require = Package['newrelic-repo-5-3.noarch']


### PR DESCRIPTION
The first run on a debian server gives an error while installation the newrelic packages. This is because apt-get update is not ran directly after the repo and before the package installation. 
This cause packer to fail with puppet error 6.

Fix contains a notify to apt-get update execute after the repo declaration
