### PR TITLE
Fix PHP Warning:  Module 'newrelic' already loaded in Unknown on line 0 (Debian)

### DIFF
--- a/manifests/agent/php.pp
+++ b/manifests/agent/php.pp
@@ -15,12 +15,6 @@
 #   Main Configuration directory used for PHP.
 #   Default: OS dependant - see params.pp (String)
 #
-# [*purge_files*]
-#   Any files which should be purged following the installation. This is only
-#   necessary as the NewRelic installer adds files to every possible location,
-#   resulting in duplicate configuration.
-#   Default: OS dependant - see params.pp (Array)
-#
 # [*package_name*]
 #   Name of the package to install
 #   Default: OS dependant - see params.pp (String)
@@ -105,7 +99,6 @@ class newrelic::agent::php (
   String                   $license_key,
   Boolean                  $manage_repo             = $::newrelic::params::manage_repo,
   String                   $conf_dir                = $::newrelic::params::php_conf_dir,
-  Array                    $purge_files             = $::newrelic::params::php_purge_files,
   String                   $package_name            = $::newrelic::params::php_package_name,
   String                   $daemon_service_name     = $::newrelic::params::php_service_name,
   Array                    $extra_packages          = $::newrelic::params::php_extra_packages,
@@ -163,11 +156,6 @@ class newrelic::agent::php (
   }
 
   # == Configuration
-
-  file { $purge_files:
-    ensure  => absent,
-    require => Exec['newrelic install']
-  }
 
   $all_ini_settings = deep_merge($default_ini_settings,$ini_settings)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,7 +26,6 @@ class newrelic::params {
       $php_package_name    = 'newrelic-php5'
       $php_service_name    = 'newrelic-daemon'
       $php_conf_dir        = '/etc/php.d'
-      $php_purge_files     = []
       $php_extra_packages  = ['php-cli']
 
       if $facts['os']['release']['major'] == '7' {
@@ -56,10 +55,8 @@ class newrelic::params {
 
       if $facts['os']['release']['full'] == '16.04' {
         $php_conf_dir        = '/etc/php/7.0/mods-available'
-        $php_purge_files     = ['/etc/php/7.0/apache2/conf.d/newrelic.ini','/etc/php/7.0/fpm/conf.d/newrelic.ini']
       } else {
         $php_conf_dir        = '/etc/php5/mods-available'
-        $php_purge_files     = ['/etc/php5/apache2/conf.d/newrelic.ini','/etc/php5/fpm/conf.d/newrelic.ini']
       }
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,6 +27,7 @@ class newrelic::params {
       $php_service_name    = 'newrelic-daemon'
       $php_conf_dir        = '/etc/php.d'
       $php_extra_packages  = ['php-cli']
+      $run_installer       = true
 
       if $facts['os']['release']['major'] == '7' {
         # Abstract socket
@@ -52,6 +53,7 @@ class newrelic::params {
       $php_default_ini_settings    = {}
       $php_default_daemon_settings = {}
       $php_extra_packages          = []
+      $run_installer               = false
 
       if $facts['os']['release']['full'] == '16.04' {
         $php_conf_dir        = '/etc/php/7.0/mods-available'


### PR DESCRIPTION
In Debian systems, the .deb package installs:

```
php5/mods-available/newrelic.ini
php5/cli/conf.d/20-newrelic.ini
php5/apache2/conf.d/20-newrelic.ini
```

Additionally, this module calls newrelic-install, that places:

```
php5/cli/conf.d/newrelic.ini
php5/apache2/conf.d/newrelic.ini
```

At this point there're two files per PHP SAPI declaring `extension=newrelic.so`

So the module tries tu purge the offending files with the purge_files artifact - https://github.com/claranet/puppet-newrelic/blob/master/manifests/agent/php.pp#L18

The params value for $purge_files are missing the cli sapi, so the problem is not fixed in full. Moreover, Debian stretch and the various php versions provided by https://deb.sury.org/ allows several php versions to coexist. At the end we want to remove all those files `/etc/php/{5.6,7.0,7.1,7.2}/{apache2,cli,fpm}/conf.d/newrelic.ini`.


Let's go a step back. The debian packages already put the files in place. It's not needed to run newrelic-install. This PR removes the $purge_files thing and disables the execution of newrelic-install in debian.