### PR TITLE
Specify that only amd64 arch is available on Infra apt repo.

### DIFF
--- a/manifests/repo/infra.pp
+++ b/manifests/repo/infra.pp
@@ -29,7 +29,7 @@ class newrelic::repo::infra {
       $require = Apt::Source['newrelic-infra']
       ensure_packages('apt-transport-https')
       ::apt::source { 'newrelic-infra':
-        location => 'https://download.newrelic.com/infrastructure_agent/linux/apt',
+        location => '[arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt/',
         repos    => 'main',
         key      => {
           id  => 'A758B3FBCD43BE8D123A3476BB29EE038ECCE87C',


### PR DESCRIPTION
The download.newrelic.com apt repo doesn't provide i386 packages, leading to errors since apt tries to download a package index for both i386 and amd64 architectures, even on amd64 machines. By specifying the 'arch' parameter, we're telling Apt that only amd64 packages are available here. This resolves the error.

We also add a trailing slash to the URL, because the NR repo server can list empty dirs when the slash is missing.

All current tests pass on TravicCI. I'm not sure how to add new tests for this specific change.
The change also works fine on our Ubuntu 12.04 and 14.04 test servers.
