### PR TITLE
Add newrelic::agent::java class

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 1. [Setup - The basics of getting started with puppet-newrelic](#setup)
     * [What puppet-newrelic affects](#what-puppet-newrelic-affects)
     * [Beginning with puppet-newrelic](#beginning-with-registry)
+1. [Supported agents]
+    * [PHP](#php_agent)
+    * [Java](#java_agent)
 1. [Usage - Configuration options and additional functionality](#usage)
 1. [Limitations - OS compatibility, etc.](#limitations)
 1. [Development - Guide for contributing to the module](#development)
@@ -46,6 +49,7 @@ To install the (deprecated) NewRelic Server Monitoring agent instead of the defa
       enable_server => true,
     }
 
+<a name="php_agent"></a>
 To enable the PHP agent with default configuration:
 
     class { '::newrelic':
@@ -91,6 +95,23 @@ Assumes usage of the [Slashbunny PHP-FPM module](https://github.com/Slashbunny/p
       require      => Class['::phpfpm'],
       notify       => Class['::phpfpm::service'],
     }
+
+<a name="java_agent"></a>
+#### Java Agent
+
+Install newrelic java agent at specified version into an install directory. The install directory is recommended to be the newrelic/ under your app folder.
+Ensure permissions are correct on the install folder by using agent_user/agent_group.
+
+*Note: importantly. this does not handle passing newrelic.jar to JVM_OPTS etc. Please refer to NewRelic docs here - https://docs.newrelic.com/docs/agents/java-agent/installation/install-java-agent
+
+
+    class { '::newrelic::agent::java:
+      license_key  => '3522b44f4c3f89c8566d5781bac6e0bb7dedab7z'
+    }
+
+    # or use hiera and include
+    # newrelic::agent::java::license_key: '3522b44f4c3f89c8566d5781bac6e0bb7dedab7z'
+    include ::newrelic::agent::java
 
 ## Limitations
 

--- a/manifests/agent/java.pp
+++ b/manifests/agent/java.pp
@@ -1,0 +1,99 @@
+# == Class: newrelic::agent::java
+#
+# This class install the New Relic Java Agent
+#
+# Management of the JVM opts to make use of said agent are not supported
+# and must be managed by end users seperately
+#
+# === Parameters:
+#
+# [*license_key*]
+#   NewRelic API license key (String)
+#
+# [*package_source_url*]
+#   URL for the newrelic zip. Used as the source for download of zip.
+#   Default: https://oss.sonatype.org/content/repositories/releases/com/newrelic/agent/java/newrelic-java/
+#
+# [*package_version*]
+#   Version of the newrelic java agent being used
+#   Default: 3.47.1
+#
+# [*install_dir*]
+#   Install dir for newrelic java agent.
+#   Default: /opt
+#
+# [*newrelic_application_name*]
+#   Name to give to your NewRelic application in the NewRelic GUI
+#   Default: webapp
+#
+# [*agent_user*]
+#   User for the newrelic agent
+#   Default: root
+#
+# [*agent_group*]
+#   Group for the newrelic agent
+#   Default: root
+#
+# [*manage_config*]
+#   Whether puppet should manage the newrelic.yml config file or not
+#   Default: true
+#
+class newrelic::agent::java (
+  String                                 $license_key,
+  String  $package_source_url            = 'https://oss.sonatype.org/content/repositories/releases/com/newrelic/agent/java/newrelic-java/',
+  String  $package_version               = '3.47.1',
+  String  $install_dir                   = '/opt',
+  String  $newrelic_application_name     = 'webapp',
+  String  $agent_user                    = 'root',
+  String  $agent_group                   = 'root',
+  Boolean $manage_config                 = true
+){
+
+  # == Package Installation
+  package{'unzip': ensure => installed}
+
+  # == Newrelic java agent fetch/installation
+
+  # Grab java agent verion from source URL.
+  #
+  # The default $package_source_url set within the module is pointing
+  # to the only useful/dependable place for the java agent.
+  # This can be overriden with a private nexus url for example
+  exec{'wget-newrelic-java-agent':
+    path    => ['/usr/bin', '/usr/sbin'],
+    cwd     => $install_dir,
+    command => "wget ${package_source_url}/${package_version}/newrelic-java-${package_version}.zip",
+    creates => "${install_dir}/newrelic-java-${package_version}.zip",
+    onlyif  => "test ! -f ${install_dir}/newrelic-java-${package_version}.zip"
+  }
+  ~> exec{'unzip-newrelic-java-agent-zip':
+    path        => ['/usr/bin', '/usr/sbin'],
+    cwd         => $install_dir,
+    command     => "unzip ${install_dir}/newrelic-java-${package_version}.zip",
+    creates     => "${install_dir}/newrelic",
+    refreshonly => true
+  }
+  ~> exec{'chown-newrelic-install-dir':
+    path        => ['/usr/bin', '/usr/sbin'],
+    command     => "chown -R ${agent_user}:${agent_group} ${install_dir}/newrelic",
+    refreshonly => true
+  }
+
+  # == Configuration
+
+  # manage the contents of the newrelic.yml or not
+  # if managed only license_key + app_name + env app_names are overriden/supported by module overrides
+  if $manage_config {
+    file{"${install_dir}/newrelic/newrelic.yml":
+      ensure  => 'file',
+      content => epp('newrelic/java/newrelic.yml.epp', {
+        license_key               => $license_key,
+        newrelic_application_name => $newrelic_application_name
+      }),
+      owner   => $agent_user,
+      group   => $agent_group,
+      mode    => '0755',
+      require => Exec['unzip-newrelic-java-agent-zip']
+    }
+  }
+}

--- a/manifests/agent/java.pp
+++ b/manifests/agent/java.pp
@@ -54,7 +54,9 @@ class newrelic::agent::java (
 ){
 
   # == Package Installation
-  package{'unzip': ensure => installed}
+  package{'unzip':
+    ensure => installed
+  }
 
   # == Newrelic java agent fetch/installation
 

--- a/manifests/agent/java.pp
+++ b/manifests/agent/java.pp
@@ -5,6 +5,10 @@
 # Management of the JVM opts to make use of said agent are not supported
 # and must be managed by end users seperately
 #
+# Useful docs for reference
+# - https://docs.newrelic.com/docs/agents/java-agent/installation/install-java-agent
+# - https://docs.newrelic.com/docs/agents/java-agent/installation/include-java-agent-jvm-argument
+#
 # === Parameters:
 #
 # [*license_key*]
@@ -67,16 +71,14 @@ class newrelic::agent::java (
     onlyif  => "test ! -f ${install_dir}/newrelic-java-${package_version}.zip"
   }
   ~> exec{'unzip-newrelic-java-agent-zip':
-    path        => ['/usr/bin', '/usr/sbin'],
-    cwd         => $install_dir,
-    command     => "unzip ${install_dir}/newrelic-java-${package_version}.zip",
-    creates     => "${install_dir}/newrelic",
-    refreshonly => true
+    path    => ['/usr/bin', '/usr/sbin'],
+    cwd     => $install_dir,
+    command => "unzip ${install_dir}/newrelic-java-${package_version}.zip",
+    creates => "${install_dir}/newrelic"
   }
   ~> exec{'chown-newrelic-install-dir':
-    path        => ['/usr/bin', '/usr/sbin'],
-    command     => "chown -R ${agent_user}:${agent_group} ${install_dir}/newrelic",
-    refreshonly => true
+    path    => ['/usr/bin', '/usr/sbin'],
+    command => "chown -R ${agent_user}:${agent_group} ${install_dir}/newrelic"
   }
 
   # == Configuration

--- a/manifests/agent/java.pp
+++ b/manifests/agent/java.pp
@@ -70,17 +70,23 @@ class newrelic::agent::java (
     cwd     => $install_dir,
     command => "wget ${package_source_url}/${package_version}/newrelic-java-${package_version}.zip",
     creates => "${install_dir}/newrelic-java-${package_version}.zip",
-    onlyif  => "test ! -f ${install_dir}/newrelic-java-${package_version}.zip"
+    onlyif  => "test ! -f ${install_dir}/newrelic-java-${package_version}.zip",
+    notify  => Exec['unzip-newrelic-java-agent-zip']
   }
-  ~> exec{'unzip-newrelic-java-agent-zip':
-    path    => ['/usr/bin', '/usr/sbin'],
-    cwd     => $install_dir,
-    command => "unzip ${install_dir}/newrelic-java-${package_version}.zip",
-    creates => "${install_dir}/newrelic"
+
+  exec{'unzip-newrelic-java-agent-zip':
+    path        => ['/usr/bin', '/usr/sbin'],
+    cwd         => $install_dir,
+    command     => "unzip ${install_dir}/newrelic-java-${package_version}.zip",
+    creates     => "${install_dir}/newrelic",
+    notify      => Exec['chown-newrelic-install-dir'],
+    refreshonly => true
   }
-  ~> exec{'chown-newrelic-install-dir':
-    path    => ['/usr/bin', '/usr/sbin'],
-    command => "chown -R ${agent_user}:${agent_group} ${install_dir}/newrelic"
+
+  exec{'chown-newrelic-install-dir':
+    path        => ['/usr/bin', '/usr/sbin'],
+    command     => "chown -R ${agent_user}:${agent_group} ${install_dir}/newrelic",
+    refreshonly => true
   }
 
   # == Configuration

--- a/spec/classes/newrelic_java_spec.rb
+++ b/spec/classes/newrelic_java_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'newrelic::agent::java', :type => :class do
+    let(:facts) do
+    {
+      'os' => {
+        'family'  => 'RedHat',
+        'name'    => 'CentOS',
+        'release' => {
+          'major' => '7'
+        }
+      },
+      'operatingsystem' => 'Centos',
+      'path' => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/opt/puppetlabs/puppet/bin:/root/.local/bin:/root/bin'
+   }
+  end
+
+  let(:params) do
+    {
+    :license_key => '1234567890qwerty',
+    :manage_config => true
+    }
+  end
+
+  it { is_expected.to compile }
+  it { should contain_package('unzip') }
+  it { should contain_exec('wget-newrelic-java-agent')}
+  it { should contain_file('/opt/newrelic/newrelic.yml')}
+end

--- a/templates/java/newrelic.yml.epp
+++ b/templates/java/newrelic.yml.epp
@@ -1,0 +1,300 @@
+# This file configures the New Relic Agent.  New Relic monitors
+# Java applications with deep visibility and low overhead.  For more details and additional
+# configuration options visit https://docs.newrelic.com/docs/java/java-agent-configuration.
+#
+# <%= generated_for_user %>
+#
+# This section is for settings common to all environments.
+# Do not add anything above this next line.
+common: &default_settings
+
+  # ============================== LICENSE KEY ===============================
+  # You must specify the license key associated with your New Relic
+  # account. For example, if your license key is 12345 use this:
+  # license_key: '12345'
+  # The key binds your Agent's data to your account in the New Relic service.
+  license_key: '<%= $license_key %>'
+
+  # Agent Enabled
+  # Use this setting to disable the agent instead of removing it from the startup command.
+  # Default is true.
+  agent_enabled: true
+
+  # Set the name of your application as you'd like it show up in New Relic.
+  # If enable_auto_app_naming is false, the agent reports all data to this application.
+  # Otherwise, the agent reports only background tasks (transactions for non-web applications)
+  # to this application. To report data to more than one application
+  # (useful for rollup reporting), separate the application names with ";".
+  # For example, to report data to "My Application" and "My Application 2" use this:
+  # app_name: My Application;My Application 2
+  # This setting is required. Up to 3 different application names can be specified.
+  # The first application name must be unique.
+  app_name: <%= $newrelic_application_name %>
+
+  # To enable high security, set this property to true. When in high
+  # security mode, the agent will use SSL and obfuscated SQL. Additionally,
+  # request parameters and message parameters will not be sent to New Relic.
+  high_security: false
+
+  # Set to true to enable support for auto app naming.
+  # The name of each web app is detected automatically
+  # and the agent reports data separately for each one.
+  # This provides a finer-grained performance breakdown for
+  # web apps in New Relic.
+  # Default is false.
+  enable_auto_app_naming: false
+
+  # Set to true to enable component-based transaction naming.
+  # Set to false to use the URI of a web request as the name of the transaction.
+  # Default is true.
+  enable_auto_transaction_naming: true
+
+  # The agent uses its own log file to keep its logging
+  # separate from that of your application.  Specify the log level here.
+  # This setting is dynamic, so changes do not require restarting your application.
+  # The levels in increasing order of verboseness are:
+  #   off, severe, warning, info, fine, finer, finest
+  # Default is info.
+  log_level: info
+
+  # Log all data sent to and from New Relic in plain text.
+  # This setting is dynamic, so changes do not require restarting your application.
+  # Default is false.
+  audit_mode: false
+
+  # The number of backup log files to save.
+  # Default is 1.
+  log_file_count: 1
+
+  # The maximum number of kbytes to write to any one log file.
+  # The log_file_count must be set greater than 1.
+  # Default is 0 (no limit).
+  log_limit_in_kbytes: 0
+
+  # Override other log rolling configuration and roll the logs daily.
+  # Default is false.
+  log_daily: false
+
+  # The name of the log file.
+  # Default is newrelic_agent.log.
+  log_file_name: newrelic_agent.log
+
+  # The log file directory.
+  # Default is the logs directory in the newrelic.jar parent directory.
+  #log_file_path:
+
+  # The agent communicates with New Relic via https by
+  # default.  If you want to communicate with newrelic via http,
+  # then turn off SSL by setting this value to false.
+  # This work is done asynchronously to the threads that process your
+  # application code, so response times will not be directly affected
+  # by this change.
+  # Default is true.
+  ssl: true
+
+  # Proxy settings for connecting to the New Relic server:
+  # If a proxy is used, the host setting is required.  Other settings
+  # are optional.  Default port is 8080.  The username and password
+  # settings will be used to authenticate to Basic Auth challenges
+  # from a proxy server.
+  #proxy_host: hostname
+  #proxy_port: 8080
+  #proxy_user: username
+  #proxy_password: password
+
+  # Limits the number of lines to capture for each stack trace.
+  # Default is 30
+  max_stack_trace_lines: 30
+
+  # Provides the ability to configure the attributes sent to New Relic. These
+  # attributes can be found in transaction traces, traced errors, Insight's
+  # transaction events, and Insight's page views.
+  attributes:
+
+    # When true, attributes will be sent to New Relic. The default is true.
+    enabled: true
+
+    #A comma separated list of attribute keys whose values should
+    # be sent to New Relic.
+    #include:
+
+    # A comma separated list of attribute keys whose values should
+    # not be sent to New Relic.
+    #exclude:
+
+
+  # Transaction tracer captures deep information about slow
+  # transactions and sends this to the New Relic service once a
+  # minute. Included in the transaction is the exact call sequence of
+  # the transactions including any SQL statements issued.
+  transaction_tracer:
+
+    # Transaction tracer is enabled by default. Set this to false to turn it off.
+    # This feature is not available to Lite accounts and is automatically disabled.
+    # Default is true.
+    enabled: true
+
+    # Threshold in seconds for when to collect a transaction
+    # trace. When the response time of a controller action exceeds
+    # this threshold, a transaction trace will be recorded and sent to
+    # New Relic. Valid values are any float value, or (default) "apdex_f",
+    # which will use the threshold for the "Frustrated" Apdex level
+    # (greater than four times the apdex_t value).
+    # Default is apdex_f.
+    transaction_threshold: apdex_f
+
+    # When transaction tracer is on, SQL statements can optionally be
+    # recorded. The recorder has three modes, "off" which sends no
+    # SQL, "raw" which sends the SQL statement in its original form,
+    # and "obfuscated", which strips out numeric and string literals.
+    # Default is obfuscated.
+    record_sql: obfuscated
+
+    # Set this to true to log SQL statements instead of recording them.
+    # SQL is logged using the record_sql mode.
+    # Default is false.
+    log_sql: false
+
+    # Threshold in seconds for when to collect stack trace for a SQL
+    # call. In other words, when SQL statements exceed this threshold,
+    # then capture and send to New Relic the current stack trace. This is
+    # helpful for pinpointing where long SQL calls originate from.
+    # Default is 0.5 seconds.
+    stack_trace_threshold: 0.5
+
+    # Determines whether the agent will capture query plans for slow
+    # SQL queries. Only supported for MySQL and PostgreSQL.
+    # Default is true.
+    explain_enabled: true
+
+    # Threshold for query execution time below which query plans will not
+    # not be captured.  Relevant only when `explain_enabled` is true.
+    # Default is 0.5 seconds.
+    explain_threshold: 0.5
+
+    # Use this setting to control the variety of transaction traces.
+    # The higher the setting, the greater the variety.
+    # Set this to 0 to always report the slowest transaction trace.
+    # Default is 20.
+    top_n: 20
+
+  # Error collector captures information about uncaught exceptions and
+  # sends them to New Relic for viewing.
+  error_collector:
+
+    # This property enables the collection of errors. If the property is not
+    # set or the property is set to false, then errors will not be collected.
+    # Default is true.
+    enabled: true
+
+    # Use this property to exclude specific exceptions from being reported as errors
+    # by providing a comma separated list of full class names.
+    # The default is to exclude akka.actor.ActorKilledException. If you want to override
+    # this, you must provide any new value as an empty list is ignored.
+    ignore_errors: akka.actor.ActorKilledException
+
+    # Use this property to exclude specific http status codes from being reported as errors
+    # by providing a comma separated list of status codes.
+    # The default is to exclude 404s. If you want to override
+    # this, you must provide any new value as an empty list is ignored.
+    ignore_status_codes: 404
+
+  # Transaction Events are used for Histograms and Percentiles. Unaggregated data is collected
+  # for each web transaction and sent to the server on harvest.
+  transaction_events:
+
+    # Set to false to disable transaction events.
+    # Default is true.
+    enabled: true
+
+    # Events are collected up to the configured amount. Afterwards, events are sampled to
+    # maintain an even distribution across the harvest cycle.
+    # Default is 2000.  Setting to 0 will disable.
+    max_samples_stored: 2000
+
+  # Cross Application Tracing adds request and response headers to
+  # external calls using supported HTTP libraries to provide better
+  # performance data when calling applications monitored by other New Relic Agents.
+  cross_application_tracer:
+
+    # Set to false to disable cross application tracing.
+    # Default is true.
+    enabled: true
+
+  # Thread profiler measures wall clock time, CPU time, and method call counts
+  # in your application's threads as they run.
+  # This feature is not available to Lite accounts and is automatically disabled.
+  thread_profiler:
+
+    # Set to false to disable the thread profiler.
+    # Default is true.
+    enabled: true
+
+  # New Relic Real User Monitoring gives you insight into the performance real users are
+  # experiencing with your website. This is accomplished by measuring the time it takes for
+  # your users' browsers to download and render your web pages by injecting a small amount
+  # of JavaScript code into the header and footer of each page.
+  browser_monitoring:
+
+    # By default the agent automatically inserts API calls in compiled JSPs to
+    # inject the monitoring JavaScript into web pages. Not all rendering engines are supported.
+    # See https://docs.newrelic.com/docs/java/real-user-monitoring-in-java#manual_instrumentation
+    # for instructions to add these manually to your pages.
+    # Set this attribute to false to turn off this behavior.
+    auto_instrument: true
+
+  class_transformer:
+    # This instrumentation reports the name of the user principal returned from
+    # HttpServletRequest.getUserPrincipal() when servlets and filters are invoked.
+    com.newrelic.instrumentation.servlet-user:
+      enabled: false
+
+    com.newrelic.instrumentation.spring-aop-2:
+      enabled: false
+
+    # Classes loaded by classloaders in this list will not be instrumented.
+    # This is a useful optimization for runtimes which use classloaders to
+    # load dynamic classes which the agent would not instrument.
+    classloader_excludes:
+      groovy.lang.GroovyClassLoader$InnerLoader,
+      org.codehaus.groovy.runtime.callsite.CallSiteClassLoader,
+      com.collaxa.cube.engine.deployment.BPELClassLoader,
+      org.springframework.data.convert.ClassGeneratingEntityInstantiator$ObjectInstantiatorClassGenerator,
+      org.mvel2.optimizers.impl.asm.ASMAccessorOptimizer$ContextClassLoader,
+      gw.internal.gosu.compiler.SingleServingGosuClassLoader,
+
+  # User-configurable custom labels for this agent.  Labels are name-value pairs.
+  # There is a maximum of 64 labels per agent.  Names and values are limited to 255 characters.
+  # Names and values may not contain colons (:) or semicolons (;).
+  labels:
+
+    # An example label
+    #label_name: label_value
+
+
+# Application Environments
+# ------------------------------------------
+# Environment specific settings are in this section.
+# You can use the environment to override the default settings.
+# For example, to change the app_name setting.
+# Use -Dnewrelic.environment=<environment> on the Java startup command line
+# to set the environment.
+# The default environment is production.
+
+# NOTE if your application has other named environments, you should
+# provide configuration settings for these environments here.
+
+development:
+  <<: *default_settings
+  app_name: <%= $newrelic_application_name %> (development)
+
+test:
+  <<: *default_settings
+  app_name: <%= $newrelic_application_name %> (test)
+
+production:
+  <<: *default_settings
+
+staging:
+  <<: *default_settings
+  app_name: <%= $newrelic_application_name %> (staging)


### PR DESCRIPTION
Hi all,

Added an agent class for java. 

Extremely simple in nature - deals with the fetching of the artifact @ specifed version and unpacking to install_dir with correct perms.

Does not concern itself with the JVM_OPTS etc required to invoke said newrelic.jar with a JVM. 

Raising early for comments and considerations.

```
class{'::newrelic::agent::java':
    license_key => 'somelicensekey'
}
```
pdk tests -> spec/classes/newrelic_java_spec.rb
```
pdk test unit
```
Quite a few failures in the tests but not related to this new class.