### PR TITLE
Use correct PHP configuration directory on Debian 9

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,10 +55,9 @@ class newrelic::params {
       $php_extra_packages          = []
       $run_installer               = false
 
-      if $facts['os']['release']['full'] == '16.04' {
-        $php_conf_dir        = '/etc/php/7.0/mods-available'
-      } else {
-        $php_conf_dir        = '/etc/php5/mods-available'
+      case $facts['os']['distro']['codename'] {
+        'xenial','stretch': { $php_conf_dir = '/etc/php/7.0/mods-available' }
+        default:            { $php_conf_dir = '/etc/php5/mods-available' }
       }
     }
 


### PR DESCRIPTION
On Debian 9 PHP 7 is used by default. The module defaults to /etc/php5/mods-available for the configuration directory on Debian systems.

This commit ensures that the correct directory is used on Debian 9 (/etc/php7.0/mods-available).