### PR TITLE
Increase the allowed version constraints

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.3.0 < 5.0.0"
+      "version_requirement": ">= 2.3.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.16.0 < 5.0.0"
+      "version_requirement": ">= 4.16.0 < 6.0.0"
     },
     {
       "name": "puppet/download_file",


### PR DESCRIPTION
This tiny change widens the version constraints as defined in metadata.json for puppetlabs/stdlib and puppetlabs/apt to allow the latest versions. 

We require the latest 6.x version of puppetlabs/apt but this module was preventing us from doing that. 